### PR TITLE
SAM created APIs now use `api.mirrulations.org`

### DIFF
--- a/documentation/referenceDocuments/ACMCertificate.md
+++ b/documentation/referenceDocuments/ACMCertificate.md
@@ -1,0 +1,16 @@
+# How to create and validate an Amazon Certificates Manager SSL Certificate
+- Create a Hosted Zone in Route 53 (if needed) (see this [document](./route53HostedZone.md))
+- Create a CNAME Record in that hosted zone:
+    - Click on the "Create record" button. ![Click the orange button](Images/createRecord.png)
+    - Select "Simple routing," click "Next," then click "Define simple record."
+        - If there is no "Simple routing" box click "Switch to wizard" in the top right. ![Switch button in the top right](Images/wizard_switch_prompt.png)
+    - Enter your subdomain, use record type "CNAME," type the upper level domain into the value entry box, and click "Define simple record." ![Define simple record modal](Images/define_simple_record_modal.png)
+- Create a certificate in ACM:
+    - Go to AWS Certificate Manager and click "Request a certificate."
+    - Select "Request a public certificate" and click "Next".
+    - Enter your full subdomain into the "Fully qualified domain name" field, select "DNS validation," and click "Request." ![Certificate request form](Images/certificate_request_form.png)
+    - Click "create records in Route 53."
+    - Your Certificate status should update to "Issued" in less than a minute. If it takes any longer than 10 minutes, double check your work.
+- Remove original CNAME record:
+    - Go to Route 53 -> Hosted Zones -> your hosted zone.
+    - Select the CNAME record and click delete record.

--- a/documentation/referenceDocuments/route53HostedZone.md
+++ b/documentation/referenceDocuments/route53HostedZone.md
@@ -1,0 +1,3 @@
+# How to Create a Route 53 Hosted Zone
+- Go to Route 53 -> Hosted Zones -> Create Hosted Zone. ![Click the orange button](Images/aws_route53.png)
+- Enter your domain name (for example `test.org`, not `api.test.org`) and click "Create hosted zone" at the bottom of the page.

--- a/documentation/staticDomain.md
+++ b/documentation/staticDomain.md
@@ -1,26 +1,11 @@
 # How to set up a static domain for an API Gateway
 ## Prerequisites
-- Have an API with a deployed stage. (see [this tutorial](https://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started.html))
-- Have your domain registered in Route 53 (ask Coleman)
-- Have an ACM (amazon certificate manager) certificate for your subdomain.
-    - Create a Hosted Zone in Route 53:
-        - Go to Route 53 -> Hosted Zones -> Create Hosted Zone. ![Click the orange button](Images/aws_route53.png)
-        - Enter your domain name (for example `test.org`, not `api.test.org`) and click "Create hosted zone" at the bottom of the page.
-    - Create a CNAME Record in that hosted zone:
-        - Click on the "Create record" button. ![Click the orange button](Images/createRecord.png)
-        - Select "Simple routing," click "Next," then click "Define simple record."
-            - If there is no "Simple routing" box click "Switch to wizard" in the top right. ![Switch button in the top right](Images/wizard_switch_prompt.png)
-        - Enter your subdomain, use record type "CNAME," type the upper level domain into the value entry box, and click "Define simple record." ![Define simple record modal](Images/define_simple_record_modal.png)
-    - Create a certificate in ACM:
-        - Go to AWS Certificate Manager and click "Request a certificate."
-        - Select "Request a public certificate" and click "Next".
-        - Enter your full subdomain into the "Fully qualified domain name" field, select "DNS validation," and click "Request." ![Certificate request form](Images/certificate_request_form.png)
-        - Click "create records in Route 53."
-        - Your Certificate status should update to "Issued" in less than a minute. If it takes any longer than 10 minutes, double check your work.
-    - Remove original CNAME record:
-        - Go to Route 53 -> Hosted Zones -> your hosted zone.
-        - Select the CNAME record and click delete record.
-## Process
+- Your domain registered in Route 53 (ask Coleman)
+- A Route 53 Hosted Zone (see this [document](./referenceDocuments/route53HostedZone.md)) 
+- An ACM (amazon certificate manager) certificate for your subdomain. (see this [document](./referenceDocuments/ACMCertificate.md))
+
+## Manual Setup
+- Create an API with a deployed stage. (see [this tutorial](https://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started.html))
 - Enter Domain into API Gateway:
     - Go to API Gateway -> "Custom Domain names" and click "Add domain name."
     - Enter your subdomain, select your certificate, and click "Add domain name." ![Adding your domain name to API Gateway](Images/api_gateway_domain_setup.png)

--- a/documentation/staticDomain.md
+++ b/documentation/staticDomain.md
@@ -20,3 +20,11 @@
 - You should now be able to run `curl https://<your_subdomain>/<endpoint>` and see the correct return value.
 
 Adapted from [this](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-custom-domains.html) AWS Documentation.
+
+## Common issues with SAM Setup
+- Sam deploy process stalling on creating `APIBaseMapping`
+    - Remove any record from the hosted zone that is linked to an API Gateway. One might be left over from the manual setup
+- Sam deploy process fails because `The domain name you provided already exists`.
+    - If it exists, remove the custom domain for API Gateway in the AWS Console.
+- Sam deploy process fails because `<DOMAINNAME> already exists in stack <ARN>`
+    - Go to AWS CloudFormation and delete any stack with the domain name. This will usually be a stack that failed and is labeled `FAILED_TO_CREATE`.

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -3,7 +3,7 @@ version = 0.1
 [default]
 [default.deploy]
 [default.deploy.parameters]
-stack_name = "sam-app-dev"
+stack_name = "api-dev"
 region = "us-east-1"
 confirm_changeset = false
 capabilities = "CAPABILITY_IAM"
@@ -12,7 +12,7 @@ disable_rollback = true  # Example: Allow more tolerance in dev for errors
 [prod]
 [prod.deploy]
 [prod.deploy.parameters]
-stack_name = "sam-app-prod"
+stack_name = "api-prod"
 region = "us-east-1"
 confirm_changeset = true  # Example: Ensure manual review of changesets in prod
 capabilities = "CAPABILITY_IAM"

--- a/template.yaml
+++ b/template.yaml
@@ -5,6 +5,13 @@ Resources:
     Type: AWS::Serverless::Api
     Properties:
       StageName: prod
+      Domain:
+        DomainName: api.mirrulations.org
+        CertificateArn: arn:aws:acm:us-east-1:936771282063:certificate/6136e1ea-86d9-49e4-a2f5-ef125433b674
+        EndpointConfiguration: EDGE
+        Route53:
+          HostedZoneId: Z06776181JN8EMX6YTN2B
+
   ApiFunction: # Adds a GET method at the root resource via an Api event
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
Other changes:
- Changed the SAM stack names to help with the abundance of resources named SAM in our AWS account.
- Reorganize and updated the static domain docs

This is ready for review!