### PR TITLE
Fix regarding errors when two pushes are done back to back

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -44,7 +44,8 @@ jobs:
           max_wait=600
           wait_interval=30
           elapsed=0
-          echo "Stack status: $(aws cloudformation describe-stacks --stack-name "$stack_name" --query 'Stacks[0].StackStatus')"          while [ $elapsed -lt $max_wait ]; do
+          echo "Stack status: $(aws cloudformation describe-stacks --stack-name "$stack_name" --query 'Stacks[0].StackStatus')"          
+          while [ $elapsed -lt $max_wait ]; do
             status=$(aws cloudformation describe-stacks --stack-name "$stack_name" --query 'Stacks[0].StackStatus' --output text 2>/dev/null)
             if [ $? -ne 0 ] || [[ " ${allowed_statuses[@]} " =~ " ${status} " ]]; then
               echo "Stack is ready or doesn't exist. Proceeding with deployment."

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -44,8 +44,7 @@ jobs:
           max_wait=600
           wait_interval=30
           elapsed=0
-          echo "Stack status: $(aws cloudformation describe-stacks --stack-name "$stack_name" --query 'Stacks[0].StackStatus)"
-          while [ $elapsed -lt $max_wait ]; do
+        echo "Stack status: $(aws cloudformation describe-stacks --stack-name "$stack_name" --query 'Stacks[0].StackStatus')"          while [ $elapsed -lt $max_wait ]; do
             status=$(aws cloudformation describe-stacks --stack-name "$stack_name" --query 'Stacks[0].StackStatus' --output text 2>/dev/null)
             if [ $? -ne 0 ] || [[ " ${allowed_statuses[@]} " =~ " ${status} " ]]; then
               echo "Stack is ready or doesn't exist. Proceeding with deployment."

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -36,9 +36,31 @@ jobs:
         run: |
           echo "Your ARN is: $(aws sts get-caller-identity --query Arn --output text)"
 
+      - name: Wait for stack to be ready
+        if: env.AWS_CREDENTIALS_PRESENT == 'true'
+        run: |
+          stack_name="api-dev"
+          allowed_statuses=("CREATE_COMPLETE" "UPDATE_COMPLETE" "ROLLBACK_COMPLETE" "UPDATE_ROLLBACK_COMPLETE")
+          max_wait=600
+          wait_interval=30
+          elapsed=0
+          while [ $elapsed -lt $max_wait ]; do
+            status=$(aws cloudformation describe-stacks --stack-name "$stack_name" --query 'Stacks[0].StackStatus' --output text 2>/dev/null)
+            if [ $? -ne 0 ] || [[ " ${allowed_statuses[@]} " =~ " ${status} " ]]; then
+              echo "Stack is ready or doesn't exist. Proceeding with deployment."
+              break
+            fi
+            echo "Stack is not ready for update. Current status: $status. Waiting..."
+            sleep $wait_interval
+            elapsed=$((elapsed + wait_interval))
+          done
+          if [ $elapsed -ge $max_wait ]; then
+            echo "Timeout waiting for stack to be ready after $max_wait seconds."
+            exit 1
+          fi
+
       - name: Deploy with SAM
         if: env.AWS_CREDENTIALS_PRESENT == 'true'
         run: |
           sam deploy --config-file samconfig.toml --config-env default --resolve-s3 --no-confirm-changeset --no-fail-on-empty-changeset
-
       - run: echo "This job's status is ${{ job.status }}."

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: deployment-${{ github.ref }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     steps:
       - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -44,6 +44,7 @@ jobs:
           max_wait=600
           wait_interval=30
           elapsed=0
+          echo "Stack status: $(aws cloudformation describe-stacks --stack-name "$stack_name" --query 'Stacks[0].StackStatus)"
           while [ $elapsed -lt $max_wait ]; do
             status=$(aws cloudformation describe-stacks --stack-name "$stack_name" --query 'Stacks[0].StackStatus' --output text 2>/dev/null)
             if [ $? -ne 0 ] || [[ " ${allowed_statuses[@]} " =~ " ${status} " ]]; then

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -44,7 +44,7 @@ jobs:
           max_wait=600
           wait_interval=30
           elapsed=0
-        echo "Stack status: $(aws cloudformation describe-stacks --stack-name "$stack_name" --query 'Stacks[0].StackStatus')"          while [ $elapsed -lt $max_wait ]; do
+          echo "Stack status: $(aws cloudformation describe-stacks --stack-name "$stack_name" --query 'Stacks[0].StackStatus')"          while [ $elapsed -lt $max_wait ]; do
             status=$(aws cloudformation describe-stacks --stack-name "$stack_name" --query 'Stacks[0].StackStatus' --output text 2>/dev/null)
             if [ $? -ne 0 ] || [[ " ${allowed_statuses[@]} " =~ " ${status} " ]]; then
               echo "Stack is ready or doesn't exist. Proceeding with deployment."

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,10 +1,16 @@
 name: GitHub Actions AWS connection
 run-name: ${{ github.actor }} triggered the Github actions
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
-  Explore-GitHub-Actions:
+  deploy:
     runs-on: ubuntu-latest
+    concurrency:
+      group: deployment-${{ github.ref }}
+      cancel-in-progress: false
     steps:
       - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # API
-
+1
 
 ## How to run the API for testing
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # API
-1
+12
 
 ## How to run the API for testing
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # API
-1234
+12345
 
 ## How to run the API for testing
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # API
-12345
+123456
 
 ## How to run the API for testing
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # API
-12
+123
 
 ## How to run the API for testing
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # API
-123
+1234
 
 ## How to run the API for testing
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # API
-123456
 
 ## How to run the API for testing
 

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -3,7 +3,7 @@ version = 0.1
 [default]
 [default.deploy]
 [default.deploy.parameters]
-stack_name = "api-dev-CICD-testing"
+stack_name = "api-dev"
 region = "us-east-1"
 confirm_changeset = false
 capabilities = "CAPABILITY_IAM"

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -3,7 +3,7 @@ version = 0.1
 [default]
 [default.deploy]
 [default.deploy.parameters]
-stack_name = "api-dev"
+stack_name = "api-dev-CICD-testing"
 region = "us-east-1"
 confirm_changeset = false
 capabilities = "CAPABILITY_IAM"

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -7,7 +7,7 @@ stack_name = "api-dev"
 region = "us-east-1"
 confirm_changeset = false
 capabilities = "CAPABILITY_IAM"
-disable_rollback = true  # Example: Allow more tolerance in dev for errors
+disable_rollback = false  # Example: Allow more tolerance in dev for errors
 
 [prod]
 [prod.deploy]

--- a/template.yaml
+++ b/template.yaml
@@ -26,7 +26,7 @@ Resources:
         TestGet: # This defines the url for this endpoint
           Type: Api
           Properties:
-            Path: /dummy
+            Path: /dummy1
             Method: get
             RestApiId:
               Ref: ApiGatewayApi

--- a/template.yaml
+++ b/template.yaml
@@ -26,7 +26,7 @@ Resources:
         TestGet: # This defines the url for this endpoint
           Type: Api
           Properties:
-            Path: /dummy1
+            Path: /dummy
             Method: get
             RestApiId:
               Ref: ApiGatewayApi


### PR DESCRIPTION
This patch will change the behavior of the github actions CD.  When a push occurs while another actions is already running the actions will be cancelled and replaced by the more recent push.  In addition it adds some logic to detect the state of the stack and only pushes if the state allows changes. 