### PR TITLE
Removes dockets from display if there is no title found

### DIFF
--- a/endpoints/queries/utils/query_sql.py
+++ b/endpoints/queries/utils/query_sql.py
@@ -65,8 +65,12 @@ def append_docket_titles(dockets_list, db_conn=None):
         # Append docket titles to the dockets list
         for item in dockets_list:
             item["docketTitle"] = docket_titles.get(item["docketID"], "Title Not Found")
+
+        for idx in range(len(dockets_list)):
+            item = dockets_list[idx]
             if item["docketTitle"] == "Title Not Found":
-                dockets_list.remove(item)
+                dockets_list.pop(idx)
+                idx -= 1
                 logging.warning(f"Docket title not found for docket ID: {item['docketID']}. Removed from results.")
 
         logging.info("Docket titles successfully appended.")

--- a/endpoints/queries/utils/query_sql.py
+++ b/endpoints/queries/utils/query_sql.py
@@ -65,6 +65,9 @@ def append_docket_titles(dockets_list, db_conn=None):
         # Append docket titles to the dockets list
         for item in dockets_list:
             item["docketTitle"] = docket_titles.get(item["docketID"], "Title Not Found")
+            if item["docketTitle"] == "Title Not Found":
+                dockets_list.remove(item)
+                logging.warning(f"Docket title not found for docket ID: {item['docketID']}. Removed from results.")
 
         logging.info("Docket titles successfully appended.")
 

--- a/endpoints/queries/utils/query_sql.py
+++ b/endpoints/queries/utils/query_sql.py
@@ -66,12 +66,7 @@ def append_docket_titles(dockets_list, db_conn=None):
         for item in dockets_list:
             item["docketTitle"] = docket_titles.get(item["docketID"], "Title Not Found")
 
-        for idx in range(len(dockets_list)):
-            item = dockets_list[idx]
-            if item["docketTitle"] == "Title Not Found":
-                dockets_list.pop(idx)
-                idx -= 1
-                logging.warning(f"Docket title not found for docket ID: {item['docketID']}. Removed from results.")
+        dockets_list = [item for item in dockets_list if item["docketTitle"] != "Title Not Found"]
 
         logging.info("Docket titles successfully appended.")
 


### PR DESCRIPTION
Change for sprint 3 demo so that if the SQL database does not contain a title for the docket, the docket is not displayed.