### PR TITLE
Add local development support for OpenSearch & PostgreSQL via env.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 # The build folder for sam
 .aws-sam
 .venv
+env.json

--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ npm install -D @vitejs/plugin-react
 
 5. Launch the API, navigate to the API repo and run the following commands
 ```
-sam build
-sam local start-api
+sam build && sam local start-api --env-vars env.json --docker-network shared_network
 ```
+**Note:** Make sure that you have the env.json in the root directory as sam would need to pick up the environment variables!
+
 If you make changes to template.yaml, run sam validate to check for errors and sam build to implement the changes.
 
 Take note of your api gateway link for later, you can see it in the output under “Mounting ApiFunction at {GATEWAY_URL_HERE} [GET, OPTIONS]”
@@ -64,6 +65,31 @@ Take note of your api gateway link for later, you can see it in the output under
 - Save the file and run this command
 ```
 npm run dev
+```
+
+**NOTE:** As of currently you can only look up "National" as that is what is currently in `data-product-kit`'s `query.py`. If you want to change the searchTerm you can do so in the file:
+
+`data-pruduct-kit/queries/query.py`:
+```bash
+if __name__ == "__main__":
+    query_params = {
+        "searchTerm": "National", <--- change here
+        "pageNumber": 0,
+        "refreshResults": True,
+        "sessionID": "session1",
+        "sortParams": {
+            "sortType": "dateModified",
+            "desc": True,
+        },
+        "filterParams": {
+            "agencies": [],
+            "dateRange": {
+                "start": "1970-01-01T00:00:00Z",
+                "end": "2025-03-21T00:00:00Z",
+            },
+            "docketType": "",
+        },
+    }
 ```
 
 ### How to Launch just the API

--- a/README.md
+++ b/README.md
@@ -28,7 +28,26 @@ npm install react react-dom react-router-dom
 npm install bootstrap
 npm install -D @vitejs/plugin-react
 ```
-4. Launch the API, navigate to the API repo and run the following commands
+4. Add a env.json to add all credentials necessary
+```
+{
+    "ApiFunction": {
+      "ENVIRONMENT": "local", #specify local if working in local
+      "OPENSEARCH_HOST": "opensearch-node1",
+      "OPENSEARCH_PORT": "9200",
+      "OPENSEARCH_INITIAL_ADMIN_PASSWORD": "<password>",
+      "POSTGRES_HOST": "db",
+      "POSTGRES_PORT": "5432",
+      "POSTGRES_DB": "postgres",
+      "POSTGRES_USER": "postgres",
+      "POSTGRES_PASSWORD": "password",
+      "DB_SECRET_NAME": "mirrulationsdb/postgres/master",
+      "OS_SECRET_NAME": "mirrulationsdb/opensearch/master"
+    }
+  }
+```
+
+5. Launch the API, navigate to the API repo and run the following commands
 ```
 sam build
 sam local start-api

--- a/endpoints/queries/query.py
+++ b/endpoints/queries/query.py
@@ -5,8 +5,6 @@ from queries.utils.query_opensearch import query_OpenSearch
 from queries.utils.query_sql import append_docket_titles
 from queries.utils.sql import connect
 
-conn = connect()
-
 def filter_dockets(dockets, filter_params=None):
     if filter_params is None:
         return dockets
@@ -112,7 +110,7 @@ def drop_previous_results(searchTerm, sessionID, sortParams, filterParams):
 
 
 def storeDockets(dockets, searchTerm, sessionID, sortParams, filterParams, totalResults):
-
+    conn = connect()
 
     for i in range(min(totalResults, len(dockets))):
         values = (
@@ -171,6 +169,7 @@ def getSavedResults(searchTerm, sessionID, sortParams, filterParams):
 
 
 def search(search_params):
+    conn = connect()
     searchTerm = search_params["searchTerm"]
     pageNumber = search_params["pageNumber"]
     refreshResults = search_params["refreshResults"]

--- a/endpoints/queries/utils/opensearch.py
+++ b/endpoints/queries/utils/opensearch.py
@@ -7,7 +7,6 @@ def connect():
     from queries.utils.secrets_manager import get_secret
 
     env = os.getenv("ENVIRONMENT", "").lower()
-    print("[DEBUG] ENVIRONMENT from opensearch:", env)
 
     if env == 'local':
         print("[DEBUG] Using local environment variables for OpenSearch.")

--- a/endpoints/queries/utils/opensearch.py
+++ b/endpoints/queries/utils/opensearch.py
@@ -1,65 +1,63 @@
 import os
 from dotenv import load_dotenv
-import certifi
 import boto3
 from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
-from queries.utils.secrets_manager import get_secret
-'''
-This function creates an OpenSearch client. If the environment variables OPENSEARCH_HOST if OPENSEARCH_PORT are not
-set, an error is raised. If the host is set to 'localhost', the client is created with basic authentication. Otherwise,
-the client is created with AWS request signing. The function returns the OpenSearch client.
 
-All code that depends on whether we are connecting to a local or production OpenSearch instance is inside of this function.
-Outside of the function, interaction with the client is the same regardless of the environment.
-'''
 def connect():
+    from queries.utils.secrets_manager import get_secret
 
-    if os.getenv('OS_SECRET_NAME'):
-        secret_name = os.getenv('OS_SECRET_NAME')
-        secret = get_secret(secret_name)
-    
-        host = secret["host"]
-        port = secret['port']
-    else:
+    env = os.getenv("ENVIRONMENT", "").lower()
+    print("[DEBUG] ENVIRONMENT from opensearch:", env)
+
+    if env == 'local':
+        print("[DEBUG] Using local environment variables for OpenSearch.")
         load_dotenv()
         host = os.getenv('OPENSEARCH_HOST', 'opensearch-node1')
         port = os.getenv('OPENSEARCH_PORT', '9200')
-    region = 'us-east-1'
+        password = os.getenv('OPENSEARCH_INITIAL_ADMIN_PASSWORD')
 
-    if host is None or port is None:
+        if not password:
+            raise ValueError("Missing OPENSEARCH_INITIAL_ADMIN_PASSWORD in local environment.")
+
+        auth = ('admin', password)
+        use_ssl = False
+        verify_certs = False
+        connection_class = RequestsHttpConnection
+    else:
+        print("[DEBUG] Using AWS Secrets Manager for OpenSearch.")
+        secret_name = os.getenv('OS_SECRET_NAME', 'mirrulationsdb/opensearch/master')
+        secret = get_secret(secret_name)
+        host = secret.get("host")
+        port = secret.get("port")
+        region = os.environ.get('AWS_REGION', 'us-east-1')
+
+        auth = AWSV4SignerAuth(boto3.Session().get_credentials(), region, 'aoss')
+        use_ssl = True
+        verify_certs = False
+        connection_class = RequestsHttpConnection
+
+    if not host or not port:
         raise ValueError('Please set the environment variables OPENSEARCH_HOST and OPENSEARCH_PORT')
-    
-    if host in ['localhost', 'opensearch-node1']:
-        auth = ('admin', os.getenv('OPENSEARCH_INITIAL_ADMIN_PASSWORD'))
 
-        ca_certs_path = certifi.where()
-        # Create the client with SSL/TLS enabled, but hostname verification disabled.
-        client = OpenSearch(
-            hosts = [{'host': host, 'port': port}],
-            http_compress = True, # enables gzip compression for request bodies
-            http_auth = auth,
-            use_ssl = False,
-            verify_certs = False,
-            ssl_assert_hostname = False,
-            ssl_show_warn = False,
-            ca_certs = ca_certs_path
-        )
-
-        return client
-    
-    service = 'aoss'
-    credentials = boto3.Session().get_credentials()
-    auth = AWSV4SignerAuth(credentials, region, service)
-    # Create the client using AWS request signing
     client = OpenSearch(
-        hosts=[{'host': host, 'port': port}],
-        http_compress = True, # enables gzip compression for request bodies
+        hosts=[{'host': host, 'port': int(port)}],
+        http_compress=True,
         http_auth=auth,
-        use_ssl=True,
-        verify_certs=False,
-        connection_class=RequestsHttpConnection,
+        use_ssl=use_ssl,
+        verify_certs=verify_certs,
+        ssl_assert_hostname=False,
+        ssl_show_warn=False,
+        connection_class=connection_class,
         pool_maxsize=20,
-        timeout=60
+        timeout=30
     )
+
+    try:
+        print(f"[DEBUG] Attempting to connect to OpenSearch at {host}:{port}")
+        client.info(timeout=5)
+        print("[DEBUG] Connected successfully")
+    except Exception as e:
+        print(f"[ERROR] Failed to connect to OpenSearch: {e}")
+        raise
 
     return client

--- a/endpoints/queries/utils/query_opensearch.py
+++ b/endpoints/queries/utils/query_opensearch.py
@@ -1,7 +1,7 @@
 from queries.utils.opensearch import connect as create_client
 
+client = create_client()
 def query_OpenSearch(search_term):
-    client = create_client()
 
 
     index_name = "comments"

--- a/endpoints/queries/utils/query_opensearch.py
+++ b/endpoints/queries/utils/query_opensearch.py
@@ -1,7 +1,7 @@
 from queries.utils.opensearch import connect as create_client
 
-client = create_client()
 def query_OpenSearch(search_term):
+    client = create_client()
 
 
     index_name = "comments"

--- a/endpoints/queries/utils/secrets_manager.py
+++ b/endpoints/queries/utils/secrets_manager.py
@@ -8,9 +8,6 @@ def get_secret(secret_name):
     print("[DEBUG] ENVIRONMENT from secrets_manager:", env)
 
     if env == "local":
-        print("[DEBUG] Using local environment variables for secrets.")
-        print("[DEBUG] All env vars:", dict(os.environ))
-
         try:
             if "postgres" in secret_name:
                 return {

--- a/endpoints/queries/utils/secrets_manager.py
+++ b/endpoints/queries/utils/secrets_manager.py
@@ -1,38 +1,56 @@
 import os
 import json
 import boto3
-from botocore.exceptions import ClientError
+import traceback 
 
 def get_secret(secret_name):
-    """
-    Retrieve a secret from AWS Secrets Manager
-    Args:
-        secret_name: Name of the secret to retrieve
-    Returns:
-        dict: The secret key/value pairs
-    """
-    region_name = os.environ.get('AWS_REGION', 'us-east-1')
+    env = os.getenv("ENVIRONMENT", "").lower()
+    print("[DEBUG] ENVIRONMENT from secrets_manager:", env)
 
-    # Create a Secrets Manager client
-    session = boto3.session.Session()
-    client = session.client(
-        service_name='secretsmanager',
-        region_name=region_name
-    )
+    if env == "local":
+        print("[DEBUG] Using local environment variables for secrets.")
+        print("[DEBUG] All env vars:", dict(os.environ))
 
-    try:
-        # Get the secret value
-        response = client.get_secret_value(SecretId=secret_name)
-        print(response)
+        try:
+            if "postgres" in secret_name:
+                return {
+                    "username": os.getenv("POSTGRES_USER"),
+                    "password": os.getenv("POSTGRES_PASSWORD"),
+                    "engine": "postgres",
+                    "host": os.getenv("POSTGRES_HOST"),
+                    "port": int(os.getenv("POSTGRES_PORT")),
+                    "db": os.getenv("POSTGRES_DB")
+                }
+            elif "opensearch" in secret_name:
+                return {
+                    "host": os.getenv("OPENSEARCH_HOST"),
+                    "port": int(os.getenv("OPENSEARCH_PORT")),
+                    "password": os.getenv("OPENSEARCH_INITIAL_ADMIN_PASSWORD")
+                }
+            else:
+                raise ValueError(f"[ERROR] Unknown secret name for local: {secret_name}")
+        except Exception as e:
+            print(f"[ERROR] Exception while loading local secrets: {e}")
+            traceback.print_exc() 
+            raise e  
 
-        # Decode and parse the secret string JSON
-        if 'SecretString' in response:
-            secret = json.loads(response['SecretString'])
-            return secret
-        else:
-            print("Secret not found in expected format")
-            raise Exception("Secret not found in expected format")
+    print("[DEBUG] Fetching secret from AWS Secrets Manager.")
+    client = boto3.client('secretsmanager')
+    response = client.get_secret_value(SecretId=secret_name)
+    secret = json.loads(response['SecretString'])
 
-    except ClientError as e:
-        print(f"Error retrieving secret: {str(e)}")
-        raise e
+    if "username" in secret:
+        return {
+            "username": secret["username"],
+            "password": secret["password"],
+            "engine": secret["engine"],
+            "host": secret["host"],
+            "port": int(secret["port"]),
+            "db": secret.get("db", "postgres")
+        }
+    else:
+        return {
+            "host": secret["host"],
+            "port": int(secret["port"]),
+            "password": secret.get("password")
+        }

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -17,4 +17,4 @@ region = "us-east-1"
 confirm_changeset = true  # Example: Ensure manual review of changesets in prod
 capabilities = "CAPABILITY_IAM"
 disable_rollback = false  # Example: Automatically rollback on failure to ensure stability
-
+parameter_overrides = "ENVIRONMENT=prod OS_SECRET_NAME=mirrulationsdb/opensearch/master DB_SECRET_NAME=mirrulationsdb/postgres/master"

--- a/template.yaml
+++ b/template.yaml
@@ -67,7 +67,16 @@ Resources:
               Resource: "arn:aws:secretsmanager:us-east-1:936771282063:secret:mirrulationsdb/opensearch/master-7xJt7C"
       Environment:
         Variables:
+          ENVIRONMENT: "local"
           DB_SECRET_NAME: "mirrulationsdb/postgres/master"
           OS_SECRET_NAME: "mirrulationsdb/opensearch/master"
+          OPENSEARCH_HOST: "opensearch-node1"
+          OPENSEARCH_PORT: "9200"
+          OPENSEARCH_INITIAL_ADMIN_PASSWORD: "Soccer^5life"
+          POSTGRES_HOST: "db"
+          POSTGRES_PORT: "5432"
+          POSTGRES_DB: "postgres"
+          POSTGRES_USER: "postgres"
+          POSTGRES_PASSWORD: "password"
       Timeout: 15 
       Role: arn:aws:iam::936771282063:role/334s25_lambda_execution_opensearch

--- a/template.yaml
+++ b/template.yaml
@@ -67,16 +67,16 @@ Resources:
               Resource: "arn:aws:secretsmanager:us-east-1:936771282063:secret:mirrulationsdb/opensearch/master-7xJt7C"
       Environment:
         Variables:
-          ENVIRONMENT: "local"
-          DB_SECRET_NAME: "mirrulationsdb/postgres/master"
-          OS_SECRET_NAME: "mirrulationsdb/opensearch/master"
-          OPENSEARCH_HOST: "opensearch-node1"
-          OPENSEARCH_PORT: "9200"
-          OPENSEARCH_INITIAL_ADMIN_PASSWORD: "Soccer^5life"
-          POSTGRES_HOST: "db"
-          POSTGRES_PORT: "5432"
-          POSTGRES_DB: "postgres"
-          POSTGRES_USER: "postgres"
-          POSTGRES_PASSWORD: "password"
+          ENVIRONMENT: ""
+          DB_SECRET_NAME: ""
+          OS_SECRET_NAME: ""
+          OPENSEARCH_HOST: ""
+          OPENSEARCH_PORT: ""
+          OPENSEARCH_INITIAL_ADMIN_PASSWORD: ""
+          POSTGRES_HOST: ""
+          POSTGRES_PORT: ""
+          POSTGRES_DB: ""
+          POSTGRES_USER: ""
+          POSTGRES_PASSWORD: ""
       Timeout: 15 
       Role: arn:aws:iam::936771282063:role/334s25_lambda_execution_opensearch


### PR DESCRIPTION
- Adds support for loading OpenSearch and Postgres credentials from `env.json` when `ENVIRONMENT=local`.
- Adds defensive JSON loading in the query pipeline to handle both string and dict inputs.
- Adds documentation in `README.md` for running `sam local start-api` with the `--env-vars` and `--docker-network` options.
- Adds a debug search query template to help developers get started.
## Testing
- Successfully tested local ingestion via `docker-compose exec`
- Verified OpenSearch and PostgreSQL connections inside Docker
- Tested local SAM API endpoint with dummy search on `"National"`