### PR TITLE
replace nulls with empty string in template

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -69,13 +69,13 @@ Resources:
         Variables:
           DB_SECRET_NAME: "mirrulationsdb/postgres/master"
           OS_SECRET_NAME: "mirrulationsdb/opensearch/master"
-          OPENSEARCH_INITIAL_ADMIN_PASSWORD: null
-          OPENSEARCH_HOST: null
-          OPENSEARCH_PORT: null
-          POSTGRES_PORT: null
-          POSTGRES_DB: null
-          POSTGRES_PASSWORD: null
-          POSTGRES_HOST: null
-          POSTGRES_USER: null
+          OPENSEARCH_INITIAL_ADMIN_PASSWORD: ""
+          OPENSEARCH_HOST: ""
+          OPENSEARCH_PORT: ""
+          POSTGRES_PORT: ""
+          POSTGRES_DB: ""
+          POSTGRES_PASSWORD: ""
+          POSTGRES_HOST: ""
+          POSTGRES_USER: ""
       Timeout: 15 
       Role: arn:aws:iam::936771282063:role/334s25_lambda_execution_opensearch


### PR DESCRIPTION
Zach told me that even though the template passes validation it does not deploy properly with null values, this replaces them with empty strings.
